### PR TITLE
Improve CA package with modularity + add missing function to generate client certificates

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -1,3 +1,6 @@
+// Package ca implements certificate authority functions.
+// It generates, loads and manages the root CA certificate and key
+// that will sign the generated certificates.
 package ca
 
 import (
@@ -7,70 +10,246 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"time"
 )
 
-// GenerateRootCA creates a root CA certificate and private key, saving them to files.
-func GenerateRootCA() error {
-	// Generate a 2048-bit RSA private key for the CA
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return err
+// Configuration constants for the CA certificate
+const (
+	DefaultCAPath = "certs/ca.crt"
+	DefaultCAKeyPath = "certs/ca.key"
+	DefaultCAKeyBits = 4096
+	DefaultCAValidity = 10 * 365 * 24 *time.Hour
+	DefaultCAOrganization = "Armor Security"
+	DefaultCACommonName = "Armor Proxy Root CA"
+)
+
+// CAConfig holds the configuration options for generating a Certificate Authority
+type CAConfig struct {
+	// CertPath is the file path to store the CA certificate
+	CertPath string
+
+	// KeyPath is the file path to store the CA private key
+	KeyPath string
+
+	// KeyBits is the RSA key size in bits
+	KeyBits int
+
+	// Validity defines how long the CA certificate will be valid
+	Validity time.Duration
+
+	// Organization is the organization name in the certificate
+	Organization string
+
+	// CommonName is the common name in the CA certificate
+	CommonName string
+}
+
+// DefaultCAConfig returns a default configuration for CA certificate generation
+func DefaultCAConfig() CAConfig {
+	return CAConfig{
+		CertPath:	DefaultCAPath,
+		KeyPath:	DefaultCAKeyPath,
+		KeyBits:	DefaultCAKeyBits,
+		Validity:	DefaultCAValidity,
+		Organization:	DefaultCAOrganization,
+		CommonName:	DefaultCACommonName,
 	}
+}
+
+// GenerateRootCA creates a root CA certificate and private key
+// It uses the default configuration parameters.
+//
+// Returns an error if the certificate generation or saving fails.
+func GenerateRootCA() error {
+	// Use default configuration
+	return GenerateRootCAWithConfig(DefaultCAConfig())
+}
+
+// GenerateRootCAWithConfig creates a root CA certificate and private key
+// with custom configuration.
+//
+// Returns an error if the certificate generation or saving fails.
+func GenerateRootCAWithConfig(config CAConfig) error {
+	// Create directories if they don't exist
+	certDir := filepath.Dir(config.CertPath)
+	keyDir := filepath.Dir(config.KeyPath)
+
+	if err := os.MkdirAll(certDir, 0755); err != nil {
+		return fmt.Errorf("failed to create certificate directory: %w", err)
+	}
+
+	if err := os.MkdirAll(keyDir, 0755); err != nil {
+		return fmt.Errorf("failed to create key directory: %w", err)
+	}
+
+	// Generate a private key for the CA
+	// RSA is used for broad compatibility
+	priv, err := rsa.GenerateKey(rand.Reader, config.KeyBits)
+	if err != nil {
+		return fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	// Current time for certificate validity period calculation
+	now := time.Now()
 
 	// Define the CA certificate template
 	template := x509.Certificate{
-		SerialNumber: big.NewInt(1), // Unique identifier
+		SerialNumber: big.NewInt(now.UnixNano()), // Unique identifier based on current time
 		Subject: pkix.Name{
-			Organization: []string{"Aegis CA"},
-			CommonName:   "Aegis Root CA",
+			Organization: []string{config.Organization},
+			CommonName: config.CommonName,
 		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),                 // Valid for 10 years
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign, // For signing certificates
+		NotBefore: now.Add(-1 * time.Hour), // Backdate it to avoid clock skew issues
+		NotAfter: now.Add(config.Validity),
+		ExtKeyUsaage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA:                  true,
+		IsCA:	true,
+		MaxPathLen: 1,
 	}
 
-	// Create the self-signed CA certificate
-	// The returned slice is the certificate in DER encoding
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	// Create self-signed CA certificate (signed by its own key)
+	// PEM is base64 encoded format with headers and footers
+	derBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		&template, // Certificate template
+		&template, // Parent is same as template, because self-signed
+		&priv.PublicKey,
+		priv,	// Certificate will be signed by this private key
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create CA certificate: %w", err)
 	}
 
 	// Save the certificate in PEM format
-	certOut, err := os.Create("certs/ca.crt")
+	certOut, err := os.Create(config.CertPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create certificate file: %w", err)
 	}
-	defer certOut.Close()
-	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	defer certOut.Close() // File is closed even if encoding fails
+
+	err = pem.Encode(certOut, &pem.Block{
+		Type: "CERTIFICATE",
+		Bytes: derBytes,
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to encode certificate to PEM: %w", err)
 	}
 
 	// Save the private key in PEM format
-	keyOut, err := os.Create("certs/ca.key")
+	// PKCS#1 format is used for RSA keys
+	keyOut, err := os.OpenFile(config.KeyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create key file: %w", err)
 	}
-	defer keyOut.Close()
-	err = pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	defer keyOut.Close() // File is closed even if encoding fails
+
+	err = pem.Encode(keyOut, &pem.Block{
+		Type: "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to encode private key to PEM: %w", err)
 	}
 
 	return nil
 }
 
-// LoadRootCA loads the CA certificate and key from files for use in the proxy.
+// LoadRootCA loads the CA certificate and key from the default paths.
 func LoadRootCA() (*tls.Certificate, error) {
-	cert, err := tls.LoadX509KeyPair("certs/ca.crt", "certs/ca.key")
-	if err != nil {
-		return nil, err
+	return LoadRootCAFromPath(DefaultCAPath, DefaultCAKeyPath)
+}
+
+// LoadRootCAFromPath loads a CA certificate and key from specified file paths.
+func LoadRootCAFromPath(certPath, keyPath string) (*tls.Certificate, error) {
+	// Check if files exist
+	if _, err := os.Stat(certPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("certificate file not found: %s", certPath)
 	}
+
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("key file not found: %s", keyPath)
+	}
+
+	// Load the certificate and key pair
+	// Checks if they form a valid pair
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CA certificate and key: %w", err)
+	}
+	
+	// More like a defensive check to make it future-proof
+	if len(cert.Certificate) == 0 {
+		return nil, fmt.Errorf("no certificate data found in %s", certPath)
+	}
+
+	// Parse the certificate to access its fields
+	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+
+	// Parsing (x509.ParseCertificate) is expensive, so to avoid in the future,
+	// we can use the Leaf field in tls.Certificate to store the parsed version.
+	// Leaf is a pointer to the parsed x509.Certificate; it is not set automatically
+	// by tls.LoadX509KeyPair, so we have to do it manually.
+	cert.Leaf = parsedCert
+
+	// Verify that this ia actually a CA certificate
+	if !parsedCert.IsCA {
+		return nil, fmt.Errorf("loaded certificate is not a CA certificate")
+	}
+
 	return &cert, nil
 }
+
+// InstallCACertificate helps install the CA certificate into the system trust store.
+// This function returns instructions for the user to follow based on their OS.
+// Possible future improvement: Install the certificate automatically.
+func InstallCACertificate(certPath string) string {
+	instructions := fmt.Sprintf(`
+	To trust the Armor Proxy CA certificate, follow these instructions for your OS:
+
+	CA Certificate Location: %s
+
+	Windows:
+	I. Double-click the CA certificate file
+	II. Click "Install Certificate"
+	III. Select "Local Machine" and click "Next"
+	IV. Select "Place all certificates in the following store"
+	V. Click "Browse" and select "Trusted Root Certification Authorities"
+	VI. Click "Next" and then "Finish"
+
+	macOS:
+	I. Double-click the CA certificate file
+	II. It will open in Keychain Access
+	III. Enter your password to unlock the keychain
+	IV. The certificate will be added but not trusted yet
+	V. Find the certificate in the list, double-click it
+	VI. Expand the "Trust" section
+	VII. Change "When using this certificate" to "Always Trust"
+	VIII. Close the window and enter your password again
+
+	Linux (Debian/Ubuntu):
+	I. Copy the certificate: sudo cp %s /usr/local/share/ca-certificates/armor-proxy-ca.crt
+	II. Update the CA store: sudo update-ca-certificates
+
+	Linux (Fedora/RHEL):
+	I. Copy the certificate: sudo cp %s /etc/pki/ca-trust/source/ancors/armor-proxy-ca.crt
+	II. Update the CA store: sudo update-ca-trust
+
+	Firefox (All platforms):
+	Firefox uses its own certificate store:
+	I. Open Firefox and go to Settings/Preferences
+	II. Search for "certificates" and click "View Certificates"
+	III. Go to the "Authorities" tab
+	IV. Click "Import" and select the CA certificate file
+	V. Check "Trust this CA to identify websites" and click "OK"
+	`, certPath, certPath, certPath)
+
+	return instructions
+}
+// TODO: Generate certificates for the clients, so they can authenticate to Armor Proxy server

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -105,7 +105,7 @@ func GenerateRootCAWithConfig(config CAConfig) error {
 		},
 		NotBefore: now.Add(-1 * time.Hour), // Backdate it to avoid clock skew issues
 		NotAfter: now.Add(config.Validity),
-		ExtKeyUsaage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA:	true,
 		MaxPathLen: 1,


### PR DESCRIPTION
Refactors CA package; allows custom configurations for parameters like the certificate and private key paths. Now it also contains instructions for the users on how to make their system trust our CA.

Later will also have function to generate certificate for the clients, so they can authenticate to the proxy.