### PR TITLE
Use other name for the TLS server function

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 		log.Fatalf("HTTP proxy failed: %v", err)
 	}
 
-	// Start HTTPS proxy; TODO: create TLS certificate for the proxy
-	// p.StartHTTPS(":443")
+	// Start TLS proxy; TODO: create SSL certificate for the proxy
+	// p.StartTLS(":443")
 
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -147,8 +147,8 @@ func (a *ArmorProxy) StartHTTP(addr string) error {
 	return server.ListenAndServe()
 }
 
-// StartHTTPS runs an HTTPS server for the proxy.
-func (a *ArmorProxy) StartHTTPS(addr string, certFile, keyFile string) error {
+// StartTLS runs an TLS server for the proxy.
+func (a *ArmorProxy) StartTLS(addr string, certFile, keyFile string) error {
 	server := &http.Server{
 		Addr:         addr,
 		Handler:      a,
@@ -159,7 +159,7 @@ func (a *ArmorProxy) StartHTTPS(addr string, certFile, keyFile string) error {
 		},
 	}
 
-	a.logger.Printf("Starting Armor HTTPS proxy on %s", addr)
+	a.logger.Printf("Starting Armor TLS proxy on %s", addr)
 	return server.ListenAndServeTLS(certFile, keyFile)
 }
 


### PR DESCRIPTION
Instead of HTTPS, use TLS to be more technically correct.