### PR TITLE
chore: Adjust HTTP and TLS listener logging message

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -143,7 +143,7 @@ func (a *ArmorProxy) StartHTTP(addr string) error {
 		WriteTimeout: a.config.WriteTimeout,
 	}
 
-	a.logger.Printf("Starting Armor proxy on %s", addr)
+	a.logger.Printf("Starting Armor Proxy HTTP listener on %s", addr)
 	return server.ListenAndServe()
 }
 
@@ -159,7 +159,7 @@ func (a *ArmorProxy) StartTLS(addr string, certFile, keyFile string) error {
 		},
 	}
 
-	a.logger.Printf("Starting Armor TLS proxy on %s", addr)
+	a.logger.Printf("Starting Armor Proxy TLS listener on %s", addr)
 	return server.ListenAndServeTLS(certFile, keyFile)
 }
 


### PR DESCRIPTION
Adjusting the HTTP and TLS listener logging message, so it is not misleading.