### PR TITLE
Implement a Filters struct in filters.go, that will hold the different filters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /app/armor /usr/local/bin/armor
 COPY --from=builder /app/certs /certs
-EXPOSE 4090
+EXPOSE 4090 4091
 CMD ["armor"]

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -2,15 +2,23 @@ package filter
 
 import "net/http"
 
-// Blocklist contains domain to block (e.g., ad servers).
-var Blocklist = map[string]bool{
-	"tbd": true,
+// Filters contains the filters that can be applied by Armor.
+type FilterConfig struct {
+	Blocklist map[string]any
+}
+
+func DefaultFilters() FilterConfig {
+	return FilterConfig{
+		Blocklist: map[string]any{
+			"facebook.com": struct{}{},
+		},
+	}
 }
 
 // ApplyFilter checks if the request should be blocked based on the host.
-func ApplyFilter(w http.ResponseWriter, r *http.Request) bool {
-	if Blocklist[r.Host] {
-		http.Error(w, "Request blocked by Aegis", http.StatusForbidden)
+func ApplyFilter(f FilterConfig, w http.ResponseWriter, r *http.Request) bool {
+	if _, ok := f.Blocklist[r.Host]; ok {
+		http.Error(w, "Request blocked by Armor", http.StatusForbidden)
 		return true
 	}
 	return false

--- a/main.go
+++ b/main.go
@@ -22,6 +22,6 @@ func main() {
 	}
 
 	// Start HTTPS proxy; TODO: create TLS certificate for the proxy
-	// p.StartHTTPS(":443")
+	// p.StartHTTPS(":4091")
 
 }


### PR DESCRIPTION
Filters struct will hold different kind of filters, for now the Blocklist. Added an example domain for testing. Also, there was a method name change for the HTTP and TLS listeners, and Proxy struct fields, so it is easier to distinguish the two.