### PR TITLE
Dynamic plugin handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 Armor is a mitm (man-in-the-middle) proxy, that acts an as interceptor between client and target (website). It acts as a Certificate Authority (CA), which is a key function to be able to decrypt and look into HTTPS traffic.
+
+It pretends to be the target website, by tricking the client into thinking that it is the real target website. In reality, it generates a fake SSL certificate (signed by its own CA) for the target website. 

--- a/main.go
+++ b/main.go
@@ -2,16 +2,35 @@ package main
 
 import (
 	"log"
+	"os"
+	"time"
 
+	"github.com/akos011221/armor/ca"
 	"github.com/akos011221/armor/proxy"
 )
 
 func main() {
 	// Testing with the default configuration
-	config := proxy.DefaultConfig()
+	//config := proxy.DefaultConfig()
 
 	// Create a new instance of the proxy
-	p, err := proxy.NewProxy(config)
+	p, err := proxy.NewProxy(&proxy.ProxyConfig{
+		CaCfg:          ca.DefaultCAConfig(),
+		ListenAddrHTTP: ":4090",
+		ListenAddrTLS:  ":4091",
+		Verbose:        true,
+		CertCacheSize:  1000,
+		ReadTimeout:    30 * time.Second,
+		WriteTimeout:   30 * time.Second,
+		AllowInsecure:  false,
+		EnabledPlugins: []string{"blocklist"},
+		PluginsConfig: map[string]any{
+			"blocklist": map[string]bool{
+				"facebook.com": true,
+			},
+		},
+		LogDestination: os.Stdout,
+	})
 	if err != nil {
 		log.Fatalf("Failed to create proxy: %v", err)
 	}

--- a/plugin/blocklist.go
+++ b/plugin/blocklist.go
@@ -1,4 +1,4 @@
-package plugins
+package plugin
 
 import (
 	"net/http"

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,4 +1,4 @@
-package plugins
+package plugin
 
 import (
 	"errors"
@@ -51,19 +51,19 @@ func (apm *ArmorPluginManager) Register(ap ArmorPlugin) {
 // ProcessRequest iterates through all registered plugins and calls
 // their ProcessRequest method. If any plugin returns Cancel, the
 // request is cancelled and the error is returned.
-func (apm *ArmorPluginManager) ProcessRequest(r *http.Request) error {
+func (apm *ArmorPluginManager) ProcessRequest(r *http.Request) (string, ProcessResult, error) {
 	for _, plugin := range apm.plugins {
 
 		outcome, err := plugin.ProcessRequest(r)
 
 		if err != nil {
-			return fmt.Errorf("plugin %s encountered an error: %w", plugin.Name(), err)
+			return plugin.Name(), Cancel, fmt.Errorf("plugin %s encountered an error: %w", plugin.Name(), err)
 		}
 		if outcome == Cancel {
-			return fmt.Errorf("plugin %s cancelled the request", plugin.Name())
+			return plugin.Name(), Cancel, nil
 		}
 	}
-	return nil
+	return "", Continue, nil
 }
 
 // ProcessResponse iterates through all registered plugins and calls

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -199,7 +199,7 @@ func (a *ArmorProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// If a plugin cancelled (blocked) the request, then its name is
 		// stored in the pluginName variable
 		a.logger.Printf("Plugin %s cancelled the request", pluginName)
-		http.Error(w, err.Error(), http.StatusForbidden)
+		http.Error(w, fmt.Sprintf("Request was cancelled by %s", pluginName), http.StatusForbidden)
 		return
 	}
 
@@ -448,7 +448,7 @@ func isClosedConnError(err error) bool {
 }
 
 // runPlugins creates the plugin manager, plugin factory and takes care of processing the plugins.
-func runPlugins(r interface{}, pluginNames []string, pluginsConfig map[string]any) (string, plugin.ProcessResult, error) {
+func runPlugins(r any, pluginNames []string, pluginsConfig map[string]any) (string, plugin.ProcessResult, error) {
 	// Plugin manager takes care of registrating and running the plugins
 	manager := plugin.NewArmorPluginManager()
 	// Plugin factory takes care of initializing a new instance of a plugin


### PR DESCRIPTION
Currently there was a single plugin set up statically in the http.Handler. To make it more dynamic and to let the user manage it, a helper function was created in the proxy package that manages the plugins.