### PR TITLE
Use HTTP status code for plugin responses

### DIFF
--- a/plugin/block_methods.go
+++ b/plugin/block_methods.go
@@ -18,14 +18,14 @@ func (bmp *BlockMethodsPlugin) Name() string {
 }
 
 // ProcessRequest checks if the request method is blocked.
-func (bpm *BlockMethodsPlugin) ProcessRequest(r *http.Request) (ProcessResult, error) {
+func (bpm *BlockMethodsPlugin) ProcessRequest(r *http.Request) (int, error) {
 	if _, ok := bpm.methods[r.Method]; ok {
-		return Cancel, nil
+		return http.StatusMethodNotAllowed, nil
 	}
-	return Continue, nil
+	return http.StatusOK, nil
 }
 
 // ProcessResponse does nothing, let's the response pass.
-func (bpm *BlockMethodsPlugin) ProcessResponse(r *http.Response) (ProcessResult, error) {
-	return Continue, nil
+func (bpm *BlockMethodsPlugin) ProcessResponse(r *http.Response) (int, error) {
+	return http.StatusOK, nil
 }

--- a/plugin/blocklist.go
+++ b/plugin/blocklist.go
@@ -23,17 +23,17 @@ func (bp *BlocklistPlugin) Name() string {
 }
 
 // ProcessRequest checks if the request URL constains a blocked host.
-func (bp *BlocklistPlugin) ProcessRequest(r *http.Request) (ProcessResult, error) {
+func (bp *BlocklistPlugin) ProcessRequest(r *http.Request) (int, error) {
 	// Since the plugin has to check the host, it has to remove the port from req.Host
 	host := strings.TrimSpace(helpers.HostWithoutPort(r.Host))
 
 	if _, ok := bp.blocklist[host]; ok {
-		return Cancel, nil
+		return http.StatusUnauthorized, nil
 	}
-	return Continue, nil
+	return http.StatusOK, nil
 }
 
 // ProcessResponse does nothing, let's the response pass.
-func (bp *BlocklistPlugin) ProcessResponse(r *http.Response) (ProcessResult, error) {
-	return Continue, nil
+func (bp *BlocklistPlugin) ProcessResponse(r *http.Response) (int, error) {
+	return http.StatusOK, nil
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -194,21 +194,19 @@ func (a *ArmorProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// If there's any active plugin, run them
 	// pluginName is the name of the plugin if there was any that failed or cancelled teh request.
-	// outcome is the action that the plugins decided to do with the request.
+	// status is the HTTP status code that the first matched plugin wants to do with the request.
 	// err is the error, if there was any. This also cancels the request.
-	pluginName, outcome, err := a.pluginManager.ProcessRequest(r)
+	pluginName, status, err := a.pluginManager.ProcessRequest(r)
 	if err != nil {
-		// Request is cancelled not only if it's blocked by a plugin,
-		// but also if there was an error in the processing
-		a.logger.Printf("Error while processing : %v", err)
-		http.Error(w, err.Error(), http.StatusForbidden)
+		// There was an error during a plugin's processing
+		a.logger.Printf("Error sent by %s: %v", pluginName, err)
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	if outcome == plugin.Cancel {
-		// If a plugin cancelled (blocked) the request, then its name is
-		// stored in the pluginName variable
-		a.logger.Printf("Plugin %s cancelled the request", pluginName)
-		http.Error(w, fmt.Sprintf("Request was cancelled by %s", pluginName), http.StatusForbidden)
+	if status >= 400 && status < 500 {
+		// If any plugin returns a 4xx error, terminate the request
+		a.logger.Printf("Plugin %s terminated the request", pluginName)
+		http.Error(w, fmt.Sprintf("Request was terminated by %s", pluginName), status)
 		return
 	}
 


### PR DESCRIPTION
Instead of using a custom type on plugins package, use net/http's HTTP status codes for processing plugin responses. This approach is cleaner and easier to understand.