### PR TITLE
Blocklist should return 403 instead of 401

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net/http"
 	"os"
 	"time"
 
@@ -29,7 +30,8 @@ func main() {
 				"facebook.com": true,
 			},
 			"block_methods": map[string]bool{
-				"TRACE": true,
+				http.MethodTrace: true,
+				http.MethodPut:   true,
 			},
 		},
 		LogDestination: os.Stdout,

--- a/plugin/blocklist.go
+++ b/plugin/blocklist.go
@@ -28,7 +28,7 @@ func (bp *BlocklistPlugin) ProcessRequest(r *http.Request) (int, error) {
 	host := strings.TrimSpace(helpers.HostWithoutPort(r.Host))
 
 	if _, ok := bp.blocklist[host]; ok {
-		return http.StatusUnauthorized, nil
+		return http.StatusForbidden, nil
 	}
 	return http.StatusOK, nil
 }


### PR DESCRIPTION
Blocklist plugin returned the wrong HTTP status code when it blocked a request.